### PR TITLE
Implement Process Class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,24 @@ test:
   name: "as-lunatic (Linux, node latest)"
   runs-on: ubuntu-latest
   steps:
-  - name: "Check out repository"
+    - name: "Check out repository"
       uses: actions/checkout@v1
-  - name: "Setup node"
+    - name: "Setup node"
       uses: actions/setup-node@v2
       with:
         node-version: latest
-  - name: "Install rust nightly"
+    - name: "Install rust nightly"
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         override: true
-  - name: "Install lunatic"
-    run: |
-      git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
-      cd lunatic
-      cargo +nightly install --path .
-      cd ..
-  - name: "Install Assemblyscript and Test"
-    run: |
-      npm install
-      npm test
+    - name: "Install lunatic"
+      run: |
+        git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
+        cd lunatic
+        cargo +nightly install --path .
+        cd ..
+    - name: "Install Assemblyscript and Test"
+      run: |
+        npm install
+        npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "Setup node"
         uses: actions/setup-node@v2
         with:
-          node-version: latest
+          node-version: 15
       - name: "Install rust nightly"
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,24 @@ test:
   name: "as-lunatic (Linux, node latest)"
   runs-on: ubuntu-latest
   steps:
-  - name: Check out repository
+  - name: "Check out repository"
       uses: actions/checkout@v1
-  - name: Setup node
+  - name: "Setup node"
       uses: actions/setup-node@v2
       with:
         node-version: latest
-  - name: Install rust nightly
+  - name: "Install rust nightly"
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
         override: true
-  - name: Install lunatic
+  - name: "Install lunatic"
     run: |
       git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
       cd lunatic
       cargo +nightly install --path .
       cd ..
-  - name: Install Assemblyscript and Test
+  - name: "Install Assemblyscript and Test"
     run: |
       npm install
       npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,29 +4,29 @@ on:
     branches:
     - master
   pull_request:
-
-test:
-  name: "as-lunatic (Linux, node latest)"
-  runs-on: ubuntu-latest
-  steps:
-    - name: "Check out repository"
-      uses: actions/checkout@v1
-    - name: "Setup node"
-      uses: actions/setup-node@v2
-      with:
-        node-version: latest
-    - name: "Install rust nightly"
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - name: "Install lunatic"
-      run: |
-        git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
-        cd lunatic
-        cargo +nightly install --path .
-        cd ..
-    - name: "Install Assemblyscript and Test"
-      run: |
-        npm install
-        npm test
+jobs:
+  test:
+    name: "as-lunatic (Linux, node latest)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v1
+      - name: "Setup node"
+        uses: actions/setup-node@v2
+        with:
+          node-version: latest
+      - name: "Install rust nightly"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: "Install lunatic"
+        run: |
+          git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
+          cd lunatic
+          cargo +nightly install --path .
+          cd ..
+      - name: "Install Assemblyscript and Test"
+        run: |
+          npm install
+          npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI Testing
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+test:
+  name: "as-lunatic (Linux, node ${{ matrix.node_version }})"
+  runs-on: ubuntu-latest
+  steps:
+  - name: Check out repository
+      uses: actions/checkout@v1
+  - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+  - name: Install lunatic
+    run: |
+      git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
+      cd lunatic
+      cargo +nightly install --path .
+      cd ..
+  - name: Install Assemblyscript and Test
+    run: npm install && npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,20 @@ on:
   pull_request:
 
 test:
-  name: "as-lunatic (Linux, node ${{ matrix.node_version }})"
+  name: "as-lunatic (Linux, node latest)"
   runs-on: ubuntu-latest
   steps:
   - name: Check out repository
       uses: actions/checkout@v1
-  - name: Install latest nightly
+  - name: Setup node
+      uses: actions/setup-node@v2
+      with:
+        node-version: latest
+  - name: Install rust nightly
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: nightly
-          override: true
+        toolchain: nightly
+        override: true
   - name: Install lunatic
     run: |
       git clone --recurse-submodules https://github.com/lunatic-solutions/lunatic.git
@@ -23,4 +27,6 @@ test:
       cargo +nightly install --path .
       cd ..
   - name: Install Assemblyscript and Test
-    run: npm install && npm test
+    run: |
+      npm install
+      npm test

--- a/asconfig.json
+++ b/asconfig.json
@@ -2,8 +2,6 @@
   "targets": {
     "debug": {
       "lib": ["assembly/"],
-      "binaryFile": "build/test.wasm",
-      "textFile": "build/test.wat",
       "sourceMap": true,
       "debug": true
     }

--- a/asconfig.json
+++ b/asconfig.json
@@ -7,7 +7,6 @@
     }
   },
   "options": {
-    "shrinkLevel": 3,
-    "optimizeLevel": 2
+    "optimize": true
   }
 }

--- a/asconfig.json
+++ b/asconfig.json
@@ -6,5 +6,8 @@
       "debug": true
     }
   },
-  "options": {}
+  "options": {
+    "shrinkLevel": 3,
+    "optimizeLevel": 2
+  }
 }

--- a/asconfig.json
+++ b/asconfig.json
@@ -1,12 +1,11 @@
 {
   "targets": {
     "debug": {
-      "lib": ["assembly/"],
-      "sourceMap": true,
       "debug": true
     }
   },
   "options": {
-    "optimize": true
+    "lib": ["assembly/"],
+    "exportTable": true
   }
 }

--- a/assembly/index.d.ts
+++ b/assembly/index.d.ts
@@ -40,7 +40,10 @@ declare module "lunatic" {
      * @param {T} value - A given workload value for this Process.
      * @param {(value: T) => void} callback - A callback to be called on the Process thread.
      */
-    public static start<T>(value: T, callback: (val: T) => void): Process;
+    public static spawn<T>(value: T, callback: (val: T) => void): Process;
+
+    /** Cause the current process to sleep. */
+    public static sleep(ms: u64): void;
 
     /** Wait for the process to finish executing. */
     public join(): bool;

--- a/assembly/index.d.ts
+++ b/assembly/index.d.ts
@@ -27,4 +27,28 @@ declare module "lunatic" {
     /** A method for receiving a payload from a channel, returns null when there are no messages to recieve. */
     public receive(): StaticArray<u8> | null;
   }
+
+  /** A reference that reperesents a handle to a process. */
+  export class Process {
+    private _pid: u32;
+    /** The process id. */
+    public readonly pid: u32;
+
+    /**
+     * Start a process with a given value that calls the provided callback.
+     *
+     * @param {T} value - A given workload value for this Process.
+     * @param {(value: T) => void} callback - A callback to be called on the Process thread.
+     */
+    public static start<T>(value: T, callback: (val: T) => void): Process;
+
+    /** Wait for the process to finish executing. */
+    public join(): bool;
+
+    /** Detatch the process from the current thread. */
+    public detach(): void;
+
+    /** Cancel the process, terminating it. */
+    public drop(): void;
+  }
 }

--- a/assembly/lunatic.ts
+++ b/assembly/lunatic.ts
@@ -124,10 +124,6 @@ const CHANNEL_INITIAL_PAYLOAD: u32 = 0;
 @external("lunatic", "sleep_ms")
 declare function sleep(ms: u64): void;
 
-@unmanaged class FunctionReference {
-  functionIndex: u32;
-  tableEnvironmentPointer: usize;
-}
 
 @final export class Process {
   private _pid: u32 = 0;
@@ -161,7 +157,7 @@ declare function sleep(ms: u64): void;
     };
     // send the box to the new thread
     t._pid = spawn_with_context(
-      changetype<FunctionReference>(threadCallback).functionIndex,
+      threadCallback.index,
       ptr,
       offsetof<BoxWithCallback<T>>()
     );
@@ -225,7 +221,7 @@ declare function sleep(ms: u64): void;
       // spawn the thread
       let t = new Process();
       t._pid = spawn_with_context(
-        changetype<FunctionReference>(threadCallback).functionIndex,
+        threadCallback.index,
         messagePtr,
         messageLength,
       );

--- a/assembly/lunatic.ts
+++ b/assembly/lunatic.ts
@@ -1,3 +1,4 @@
+
 const enum ChannelReceivePrepareResult {
   Success = 0,
   Fail = 1,
@@ -13,6 +14,11 @@ const enum ChannelSendResult {
   Fail = 1,
 }
 
+const enum JoinResult {
+  Success = 0,
+  Fail = 1,
+}
+
 // @ts-ignore: valid decorator here
 @external("lunatic", "channel")
 declare function channel(bound: usize, receiver: usize): u32;
@@ -23,7 +29,7 @@ declare function channel_receive_prepare(channel: u32, rec: usize): ChannelRecei
 
 // @ts-ignore: valid decorator here
 @external("lunatic", "channel_receive")
-declare function channel_receive(buffer: StaticArray<u8>, length: usize): ChannelReceiveResult;
+declare function channel_receive(buffer: usize, length: usize): ChannelReceiveResult;
 
 // @ts-ignore: valid decorator here
 @external("lunatic", "channel_send")
@@ -44,11 +50,20 @@ declare function receiver_serialize(channel_id: u32): u32;
 @external("lunatic", "receiver_serialize")
 declare function receiver_deserialize(channel_id: u32): u32;
 
+// @ts-ignore: valid decorator
+@external("lunatic", "detach_process")
+declare function detach_process(pid: u32): void;
+
+// @ts-ignore: valid decorator
+@external("lunatic", "cancel_process")
+declare function cancel_process(pid: u32): void;
+
+// @ts-ignore: valid decorator
+@external("lunatic", "join")
+declare function join(pid: u32): JoinResult;
+
 // a static heap location reserved just for receiving data from lunatic
 const receive_length_pointer = memory.data(sizeof<u32>());
-
-
-
 
 // A message channel object
 @final export class Channel {
@@ -85,7 +100,137 @@ const receive_length_pointer = memory.data(sizeof<u32>());
     let length = load<u32>(receive_length_pointer);
     if (prepareResult == ChannelReceivePrepareResult.Fail) return null;
     let result = new StaticArray<u8>(length);
-    channel_receive(result, length);
+    channel_receive(changetype<usize>(result), length);
     return result;
+  }
+}
+
+// @ts-ignore: valid decorator
+@external("lunatic", "spawn_with_context")
+declare function spawn_with_context(
+  func: () => void,
+  buf_ptr: usize,
+  buf_len: usize,
+): u32;
+
+// Special class used for boxing number values to be sent across threads
+@unmanaged class BoxWithCallback<T> {
+  val: T;
+  callback: (val: T) => void;
+}
+
+const CHANNEL_INITIAL_PAYLOAD: u32 = 0;
+
+@final export class Process {
+  private _pid: u32 = 0;
+  public get pid(): u32 { return this._pid; }
+
+  // @ts-ignore: valid external reference
+  @external("lunatic", "sleep_ms")
+  declare public static sleep(ms: u64): void;
+
+  public static spawn<T>(val: T, callback: (val: T) => void): Process {
+    // All of the following are inlined compile time checks, no performance loss
+    if (isInteger<T>() || isFloat<T>()) {
+      // static memory location beneath __heap_base. no heap allocations necessary
+      let ptr = memory.data(offsetof<BoxWithCallback<T>>());
+      // we need to put the value on the heap, so box the value and the callback together
+      let box = changetype<BoxWithCallback<T>>(ptr);
+      box.val = val;
+      box.callback = callback;
+      let t = new Process();
+      // send the box to the new thread
+      t._pid = spawn_with_context(() => {
+        // Get the payload from channel 0
+        let prepareResult = channel_receive_prepare(CHANNEL_INITIAL_PAYLOAD, receive_length_pointer);
+
+        // get the payload length and assert it's the correct size
+        let length = load<u32>(receive_length_pointer);
+        if (prepareResult == ChannelReceivePrepareResult.Fail) return;
+        assert(length == offsetof<BoxWithCallback<T>>());
+
+        // obtain the static segment just for this box, store the result
+        let result = changetype<BoxWithCallback<T>>(memory.data(offsetof<BoxWithCallback<T>>()));
+        channel_receive(changetype<usize>(result), length);
+
+        // start the thread
+        result.callback(result.val);
+      }, ptr, offsetof<BoxWithCallback<T>>());
+
+      return t;
+      // if T is an array, and the values are numbers
+    } else if (isArray(val) && (isInteger<valueof<T>>() || isFloat<valueof<T>>())) {
+      ERROR("NOT IMPLEMENTED"); // for now, compile time error
+      // if the value is a typed array
+    } else if (val instanceof TypedArray) {
+      // obtain buffer data properties
+      let byteLength = <usize>val.byteLength;
+      // @ts-ignore: unsafe, undocumented, but fastest way to obtain the data pointer
+      let dataStart = val.dataStart;
+      // allocate a new message, plus callback usize
+      let messageLength = byteLength + sizeof<usize>();
+      let messagePtr = __alloc(messageLength);
+      // store the callback pointer and message contents
+      store(messagePtr, changetype<usize>(callback));
+      memory.copy(messagePtr + sizeof<usize>(), dataStart, byteLength);
+
+      // spawn the thread
+      let t = new Process();
+      t._pid = spawn_with_context(() => {
+        // Get the payload from channel 0
+        let prepareResult = channel_receive_prepare(CHANNEL_INITIAL_PAYLOAD, receive_length_pointer);
+
+        // get the payload length
+        let length = load<u32>(receive_length_pointer);
+        if (prepareResult == ChannelReceivePrepareResult.Fail) return;
+
+        // simple unmanaged heap allocation of the given length, and receive the message
+        let messagePtr = __alloc(length);
+        channel_receive(messagePtr, length);
+
+        let callback = changetype<(val: T) => void>(load<usize>(messagePtr));
+        let byteLength = length - sizeof<usize>();
+        // @ts-ignore: __pin is global but hidden
+        let buffPtr = __pin(__new(byteLength, idof<ArrayBuffer>()));
+        // @ts-ignore: __pin is global but hidden
+        let resultPtr = __pin(__new(offsetof<T>(), idof<T>()));
+
+        // set the dataview properties
+        store<usize>(resultPtr, buffPtr, offsetof<T>("dataStart"));
+        store<i32>(resultPtr, <i32>byteLength, offsetof<T>("byteLength"));
+        store<usize>(resultPtr, buffPtr, offsetof<T>("buffer"));
+
+        // copy the data to the buffer
+        memory.copy(buffPtr, messagePtr + sizeof<usize>(), byteLength);
+
+        // free the message
+        __free(messagePtr);
+
+        // start the thread
+        callback(changetype<T>(resultPtr));
+        // @ts-ignore: unpin is global, but hidden
+        __unpin(buffPtr);
+        // @ts-ignore: unpin is global, but hidden
+        __unpin(resultPtr)
+      }, messagePtr, messageLength);
+      return t;
+    } else if (isArrayLike(val)) {
+      ERROR("NOT IMPLEMENTED"); // for now, compile time error
+      // flat reference, perform a memcopy
+    } else {
+      ERROR("NOT IMPLEMENTED"); // for now, compile time error
+    }
+    ERROR("NOT IMPLEMENTED");
+    return new Process();
+  }
+
+  public drop(): void {
+    cancel_process(this._pid);
+  }
+  public detatch(): void {
+    detach_process(this._pid);
+  }
+  public join(): bool {
+    return join(this._pid) == JoinResult.Success;
   }
 }

--- a/assembly/lunatic.ts
+++ b/assembly/lunatic.ts
@@ -171,7 +171,7 @@ const CHANNEL_INITIAL_PAYLOAD: u32 = 0;
       let messageLength = byteLength + sizeof<usize>();
       let messagePtr = __alloc(messageLength);
       // store the callback pointer and message contents
-      store(messagePtr, changetype<usize>(callback));
+      store<usize>(messagePtr, changetype<usize>(callback));
       memory.copy(messagePtr + sizeof<usize>(), dataStart, byteLength);
 
       // spawn the thread

--- a/assembly/lunatic.ts
+++ b/assembly/lunatic.ts
@@ -205,7 +205,7 @@ declare function sleep(ms: u64): void;
 
     // we can obtain the dataStart and byteLength value doing a manual load here
     let dataStart = load<usize>(changetype<usize>(val), offsetof<Array<T>>("dataStart"));
-    let byteLength = load<i32>(changetype<usize>(val), offsetof<Array<T>>("byteLength"));
+    let byteLength = load<i32>(changetype<usize>(val), offsetof<Array<T>>("length_")) << alignof<T>();
 
     let threadCallback = (): void => {
       // Get the payload and the length

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "test": "run-s asbuild:channels asbuild:process test:channels test:process",
     "test:channels": "lunatic build/channels.wasm",
-    "asbuild:channels": "asc test/channels.ts --target debug --binaryFile build/channels.wasm --textFile build/channels.wat",
+    "asbuild:channels": "asc test/channels.ts --target debug --exportTable --binaryFile build/channels.wasm --textFile build/channels.wat",
     "test:process": "lunatic build/process.wasm",
-    "asbuild:process": "asc test/process.ts --target debug --binaryFile build/process.wasm --textFile build/process.wat"
+    "asbuild:process": "asc test/process.ts --target debug --exportTable --binaryFile build/process.wasm --textFile build/process.wat"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "description": "Bindings for lunatic imports",
   "main": "index.js",
   "scripts": {
-    "test": "run-s asbuild:channels test:channels",
-    "test:channels": "lunatic build/test.wasm",
-    "asbuild:channels": "asc test/channels.ts --target debug"
+    "test": "run-s asbuild:channels asbuild:process test:channels test:process",
+    "test:channels": "lunatic build/channels.wasm",
+    "asbuild:channels": "asc test/channels.ts --target debug --binaryFile build/channels.wasm --textFile build/channels.wat",
+    "test:process": "lunatic build/process.wasm",
+    "asbuild:process": "asc test/process.ts --target debug --binaryFile build/process.wasm --textFile build/process.wat"
   },
   "repository": {
     "type": "git",

--- a/test/process.ts
+++ b/test/process.ts
@@ -1,0 +1,34 @@
+// import "wasi";
+// import { Process, Channel } from "lunatic";
+// import { Console } from "as-wasi";
+// 
+// let numbers = Channel.create(0);
+// numbers.send([0, 1, 2]);
+// 
+// let p = Process.spawn<u64>(numbers.serialize(), (val: u64) => {
+//   // This line doesn't apper to be called
+//   Console.log("Testing!\r\n");
+// });
+// Process.sleep(1000);
+// Console.log(p.join().toString() + "\r\n");
+// let result = numbers.receive()!;
+// Console.log(result.toString() + "\r\n");
+// result = numbers.receive()!;
+// assert(result[0] === 42);
+// Console.log("Success!");
+import { Console } from "as-wasi";
+import "wasi";
+
+// @ts-ignore
+@external("lunatic", "spawn_with_context")
+declare function spawn_with_context(callback: () => void, ptr: usize, size: usize): u32;
+// @ts-ignore
+@external("lunatic", "join")
+declare function join(pid: u32): u32;
+
+let pid = spawn_with_context(() => {
+  Console.log("Hello thread!\r\n");
+}, 0, 0);
+
+Console.log("Pid: " + pid.toString());
+join(pid);

--- a/test/process.ts
+++ b/test/process.ts
@@ -2,7 +2,6 @@ import "wasi";
 import { Process, Channel } from "lunatic";
 import { Console } from "as-wasi";
 
-<<<<<<< HEAD
 let numbers = Channel.create(0);
 numbers.send([0, 1, 2]);
 
@@ -15,20 +14,6 @@ let p = Process.spawn<u64>(numbers.serialize(), (val: u64) => {
   assert(a[2] == 2);
   numbers.send([42]);
 });
-=======
-// @ts-ignore
-@external("lunatic", "spawn_with_context")
-declare function spawn_with_context(callback: u32, ptr: usize, size: usize): u32;
-// @ts-ignore
-@external("lunatic", "join")
-declare function join(pid: u32): u32;
-
-let closure = (): void => {
-  Console.log("Hello thread!\r\n");
-};
-let table_index = load<u32>(<u32>changetype<usize>(closure));
-let pid = spawn_with_context(table_index, 0, 0);
->>>>>>> 74ba5596157cf886737373b4513ba474fef71219
 
 // assert(p.join());
 p.join();

--- a/test/process.ts
+++ b/test/process.ts
@@ -21,14 +21,16 @@ import "wasi";
 
 // @ts-ignore
 @external("lunatic", "spawn_with_context")
-declare function spawn_with_context(callback: () => void, ptr: usize, size: usize): u32;
+declare function spawn_with_context(callback: u32, ptr: usize, size: usize): u32;
 // @ts-ignore
 @external("lunatic", "join")
 declare function join(pid: u32): u32;
 
-let pid = spawn_with_context(() => {
+let closure = (): void => {
   Console.log("Hello thread!\r\n");
-}, 0, 0);
+};
+let table_index = load<u32>(<u32>changetype<usize>(closure));
+let pid = spawn_with_context(table_index, 0, 0);
 
 Console.log("Pid: " + pid.toString());
 join(pid);

--- a/test/process.ts
+++ b/test/process.ts
@@ -17,6 +17,6 @@ let p = Process.spawn<u64>(numbers.serialize(), (val: u64) => {
 
 assert(p.join());
 let b = numbers.receive()!;
-assert(b.length == 1); // assertion fails, because it receives the first reference
+assert(b.length == 1);
 assert(b[0] == 42);
 Console.log("[Pass] Simple thread with channel pass");

--- a/test/process.ts
+++ b/test/process.ts
@@ -66,3 +66,23 @@ let typedArrayProcess = Process.spawn<Uint32Array>(typedArray, (val: Uint32Array
 });
 assert(typedArrayProcess.join());
 Console.log("[Pass] Thread with typedarray\r\n");
+
+// inlined static memory segment
+let staticArray = [300, 1000, -42] as StaticArray<i16>;
+let staticArrayProcess = Process.spawn(staticArray, (val: StaticArray<i16>) => {
+  assert(val[0] == 300);
+  assert(val[1] == 1000);
+  assert(val[2] == -42);
+});
+assert(staticArrayProcess.join());
+Console.log("[Pass] Thread with static staticarray segment\r\n");
+
+// dynamic allocation static array
+let allocatedStaticArray = new StaticArray<u8>(5);
+for (let i = 0; i < 5; i++) allocatedStaticArray[i] = <u8>i;
+
+let allocatedStaticArrayProcess = Process.spawn(allocatedStaticArray, (val: StaticArray<u8>) => {
+  for (let i = 0; i < 5; i++) assert(val[i] == <u8>i);
+});
+assert(allocatedStaticArrayProcess.join());
+Console.log("[Pass] Thread with allocated staticarray segment\r\n");

--- a/test/process.ts
+++ b/test/process.ts
@@ -2,6 +2,12 @@ import "wasi";
 import { Process, Channel } from "lunatic";
 import { Console } from "as-wasi";
 
+let simpleValueProcess = Process.spawn(42, (val: i32) => {
+  assert(val == 42);
+});
+assert(simpleValueProcess.join());
+Console.log("[Pass] Thread with simple value\r\n");
+
 let numbers = Channel.create(0);
 numbers.send([0, 1, 2]);
 
@@ -19,4 +25,44 @@ assert(p.join());
 let b = numbers.receive()!;
 assert(b.length == 1);
 assert(b[0] == 42);
-Console.log("[Pass] Simple thread with channel pass");
+Console.log("[Pass] Simple thread with channel pass\n");
+
+class Vec3 {
+  constructor(
+    public x: f32,
+    public y: f32,
+    public z: f32,
+  ) {}
+}
+
+let vector = new Vec3(1, 2, 3);
+
+let vecProcess = Process.spawn<Vec3>(vector, (vec: Vec3) => {
+  assert(vec.x == 1);
+  assert(vec.y == 2);
+  assert(vec.z == 3);
+});
+assert(vecProcess.join());
+Console.log("[Pass] Thread with flat reference\r\n");
+
+
+let arrayProcess = Process.spawn<Array<f32>>([24, 6, 9], (val: Array<f32>) => {
+  assert(val[0] == 24);
+  assert(val[1] == 6);
+  assert(val[2] == 9);
+});
+assert(arrayProcess.join());
+Console.log("[Pass] Thread with array\r\n");
+
+let typedArray = new Uint32Array(3);
+typedArray[0] = 1000;
+typedArray[1] = 255;
+typedArray[2] = 9001;
+
+let typedArrayProcess = Process.spawn<Uint32Array>(typedArray, (val: Uint32Array) => {
+  assert(val[0] == 1000);
+  assert(val[1] == 255);
+  assert(val[2] == 9001);
+});
+assert(typedArrayProcess.join());
+Console.log("[Pass] Thread with typedarray\r\n");

--- a/test/process.ts
+++ b/test/process.ts
@@ -15,8 +15,7 @@ let p = Process.spawn<u64>(numbers.serialize(), (val: u64) => {
   numbers.send([42]);
 });
 
-// assert(p.join());
-p.join();
+assert(p.join());
 let b = numbers.receive()!;
 assert(b.length == 1); // assertion fails, because it receives the first reference
 assert(b[0] == 42);

--- a/test/process.ts
+++ b/test/process.ts
@@ -1,34 +1,23 @@
-// import "wasi";
-// import { Process, Channel } from "lunatic";
-// import { Console } from "as-wasi";
-// 
-// let numbers = Channel.create(0);
-// numbers.send([0, 1, 2]);
-// 
-// let p = Process.spawn<u64>(numbers.serialize(), (val: u64) => {
-//   // This line doesn't apper to be called
-//   Console.log("Testing!\r\n");
-// });
-// Process.sleep(1000);
-// Console.log(p.join().toString() + "\r\n");
-// let result = numbers.receive()!;
-// Console.log(result.toString() + "\r\n");
-// result = numbers.receive()!;
-// assert(result[0] === 42);
-// Console.log("Success!");
-import { Console } from "as-wasi";
 import "wasi";
+import { Process, Channel } from "lunatic";
+import { Console } from "as-wasi";
 
-// @ts-ignore
-@external("lunatic", "spawn_with_context")
-declare function spawn_with_context(callback: () => void, ptr: usize, size: usize): u32;
-// @ts-ignore
-@external("lunatic", "join")
-declare function join(pid: u32): u32;
+let numbers = Channel.create(0);
+numbers.send([0, 1, 2]);
 
-let pid = spawn_with_context(() => {
-  Console.log("Hello thread!\r\n");
-}, 0, 0);
+let p = Process.spawn<u64>(numbers.serialize(), (val: u64) => {
+  let numbers = Channel.deserialize(val);
+  let a = numbers.receive()!;
+  assert(a.length == 3);
+  assert(a[0] == 0);
+  assert(a[1] == 1);
+  assert(a[2] == 2);
+  numbers.send([42]);
+});
 
-Console.log("Pid: " + pid.toString());
-join(pid);
+// assert(p.join());
+p.join();
+let b = numbers.receive()!;
+assert(b.length == 1); // assertion fails, because it receives the first reference
+assert(b[0] == 42);
+Console.log("[Pass] Simple thread with channel pass");


### PR DESCRIPTION
Small functions implemented.

Things to note:

- There is no way to serialize references because AS has a lack of reflection
- Every reference must be marshalled manually by the end user, unless it is an `Array<T>` where `T` is a number type
- `TypedArray`s and `Array`s have backing buffers, and that's the data we are copying, but the marshalling service needs overhead to assemble it
- StaticArrays have a single heap allocation, and it should be easy to implement
- Simple values, because the stack cannot be reference must be boxed manually, but are also very easy to marshal

The overhead for starting a process with arrays is at least a heap allocation and a memcopy. (`TypedArray` or `Array` dataview buffer needs to be marshalled in combination with the callback.)

The overhead for running a child process with arrays is a few heap allocations (depending on the type) and a memcopy. This is all very unfortunate, and is done rather trivially in Rust, but that's because Rust handles stack references behind the scenes.

All in all, mostly done. Just need to add a few more implementations for `Process.start()`.

Any ideas?
