### PR TITLE
@ason/assembly is required for compilation, so it's a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "url": "https://github.com/lunatic-solutions/as-lunatic/issues"
   },
   "homepage": "https://github.com/lunatic-solutions/as-lunatic#readme",
+  "dependencies": {
+    "@ason/assembly": "0.0.3"
+  },
   "devDependencies": {
-    "@ason/assembly": "0.0.3",
     "assemblyscript": "^0.18.30",
     "npm-run-all": "^4.1.5"
   }


### PR DESCRIPTION
When trying to follow the instructions on the readme, I realized that ASON was not automatically installed when depending on `as-lunatic` as a devDependency. This will make it so that developers won't even have to think about installing ason, since it's already required.