### PR TITLE
Remove an extra space in trace() for null messages

### DIFF
--- a/assembly/entry.ts
+++ b/assembly/entry.ts
@@ -43,9 +43,8 @@ export function __lunatic_abort(
 
   if (message) {
     ptr += String.UTF8.encodeUnsafe(changetype<usize>(message), message.length, ptr);
+    store<u32>(ptr, 0x206E6920); ptr += 4; // ' in '
   }
-
-  store<u32>(ptr, 0x206E6920); ptr += 4; // ' in '
 
   if (fileName) {
     ptr += String.UTF8.encodeUnsafe(changetype<usize>(fileName), fileName.length, ptr);


### PR DESCRIPTION
The " in " string is now only printed when trace() is passed a message.

Before, null message:  "abort:  in assembly/index.ts(151:5)"
After, null message:   "abort: assembly/index.ts(151:5)"
Both, nonnull message: "abort: pqrst in uvwxyz(12:345)"