### PR TITLE
Add more SharedMap methods and improve it further

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -2,6 +2,7 @@ export * from "./distributed";
 export * from "./distributed/bindings";
 export * from "./error";
 export * from "./error/bindings";
+export * from "./managed";
 export * from "./message";
 export * from "./message/bindings";
 export * from "./message/util";

--- a/assembly/managed/index.ts
+++ b/assembly/managed/index.ts
@@ -3,7 +3,7 @@ import { MessageType } from "../message/util";
 import { Process } from "../process";
 
 export class SharedMap<TValue> {
-  self: Process<SharedMapEvent<TValue>> = Process.inheritSpawn((mb: Mailbox<SharedMapEvent<TValue>>) => {
+  private self: Process<SharedMapEvent<TValue>> = Process.inheritSpawn((mb: Mailbox<SharedMapEvent<TValue>>) => {
     let map = new Map<string, TValue>();
     while (true) {
       let message = mb.receive();
@@ -19,6 +19,17 @@ export class SharedMap<TValue> {
         } else if (event instanceof DeleteSharedMapEvent<TValue>) {
           let key = (<DeleteSharedMapEvent<TValue>>event).key;
           map.delete(key);
+        } else if (event instanceof ClearSharedMapEvent<TValue>) {
+          map.clear();
+        } else if (event instanceof HasSharedMapEvent<TValue>) {
+          const key = (<HasSharedMapEvent<TValue>>event).key;
+          message.reply<bool>(map.has(key));
+        } else if (event instanceof SizeSharedMapEvent<TValue>) {
+          message.reply<i32>(map.size);
+        } else if (event instanceof KeysSharedMapEvent<TValue>) {
+          message.reply<string[]>(map.keys());
+        } else if (event instanceof ValuesSharedMapEvent<TValue>) {
+          message.reply<TValue[]>(map.values());
         }
       }
     }
@@ -31,20 +42,54 @@ export class SharedMap<TValue> {
     return message.box!.value;
   }
 
-  set(key: string, value: TValue): void {
+  set(key: string, value: TValue): this {
     let event = new SetSharedMapEvent<TValue>(key, value);
     this.self.send(event);
+    return this;
   }
 
   delete(key: string): void {
     let event = new DeleteSharedMapEvent<TValue>(key);
     this.self.send(event);
   }
+
+  clear(): void {
+    const event = new ClearSharedMapEvent<TValue>();
+    this.self.send(event);
+  }
+
+  has(key: string): bool {
+    const event = new HasSharedMapEvent<TValue>(key);
+    const message = this.self.request<HasSharedMapEvent<TValue>, bool>(event);
+    assert(message.type == MessageType.Data);
+    return message.box!.value;
+  }
+
+  get size(): i32 {
+    const event = new SizeSharedMapEvent<TValue>();
+    const message = this.self.request<SizeSharedMapEvent<TValue>, i32>(event);
+    assert(message.type == MessageType.Data);
+    return message.box!.value;
+  }
+
+  keys(): string[] {
+    const event = new KeysSharedMapEvent<TValue>();
+    const message = this.self.request<KeysSharedMapEvent<TValue>, string[]>(event);
+    assert(message.type == MessageType.Data);
+    return message.box!.value;
+  }
+
+  values(): TValue[] {
+    const event = new ValuesSharedMapEvent<TValue>();
+    const message = this.self.request<ValuesSharedMapEvent<TValue>, TValue[]>(event);
+    assert(message.type == MessageType.Data);
+    return message.box!.value;
+  }
 }
 
-export abstract class SharedMapEvent<TValue> {}
+abstract class SharedMapEvent<TValue> {}
 
-export class GetSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
+class GetSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
   constructor(
     public key: string
   ) {
@@ -52,7 +97,7 @@ export class GetSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
   }
 }
 
-export class DeleteSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
+class DeleteSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
   constructor(
     public key: string
   ) {
@@ -60,7 +105,7 @@ export class DeleteSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
   }
 }
 
-export class SetSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
+class SetSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
   constructor(
     public key: string,
     public value: TValue,
@@ -68,3 +113,17 @@ export class SetSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
     super();
   }
 }
+
+class ClearSharedMapEvent<TValue> extends SharedMapEvent<TValue> {}
+
+class HasSharedMapEvent<TValue> extends SharedMapEvent<TValue> {
+  constructor(public key: string) {
+    super();
+  }
+}
+
+class SizeSharedMapEvent<TValue> extends SharedMapEvent<TValue> {}
+
+class KeysSharedMapEvent<TValue> extends SharedMapEvent<TValue> {}
+
+class ValuesSharedMapEvent<TValue> extends SharedMapEvent<TValue> {}


### PR DESCRIPTION
This commit implements every public Map method and property. Also, the SharedMap class is now re-exported by index.ts. Lastly, the self field in the SharedMap class and the event classes have been made private.

The new methods may need more testing.